### PR TITLE
Accessibility form fine-tuning

### DIFF
--- a/src/features/DatasetPicker.tsx
+++ b/src/features/DatasetPicker.tsx
@@ -21,6 +21,7 @@ type Props = {
   disabled?: boolean;
   onChange: (value: any) => void;
   required?: boolean;
+  recommendedOption?: boolean;
 };
 
 const QUERY = gql`
@@ -78,7 +79,15 @@ const RECOMMENDED_OPTION = {
 };
 
 const DatasetPicker = (props: Props) => {
-  const { value, onChange, disabled, required, project, roleCode } = props;
+  const {
+    value,
+    onChange,
+    disabled,
+    required,
+    project,
+    roleCode,
+    recommendedOption = false,
+  } = props;
   const [roles, setRoles] = useState<
     {
       id: string;
@@ -117,10 +126,11 @@ const DatasetPicker = (props: Props) => {
     getFilesetRoles().then((roles) => setRoles(roles));
   }, []);
 
-  // We add the `Recommended dataset` option in the list
+  // We add the `Recommended dataset` option in the list if activated
   const options = useMemo(() => {
-    return [RECOMMENDED_OPTION, ...(data?.filesets?.items ?? [])];
-  }, [data]);
+    const base = recommendedOption ? [RECOMMENDED_OPTION] : [];
+    return [...base, ...(data?.filesets?.items ?? [])];
+  }, [data, recommendedOption]);
 
   const onCreateDialogClose = useCallback((reason?: string, fileset?: any) => {
     toggleCreateDialog();
@@ -138,7 +148,9 @@ const DatasetPicker = (props: Props) => {
         roleId: role.id,
       },
     });
-  }, [role]);
+  }, [role, fetch, project]);
+
+  const defaultValue = recommendedOption ? RECOMMENDED_OPTION : null;
 
   return (
     <>
@@ -150,8 +162,8 @@ const DatasetPicker = (props: Props) => {
       />
       <SelectInput
         options={options}
-        value={value ?? RECOMMENDED_OPTION}
-        defaultValue={RECOMMENDED_OPTION}
+        value={value ?? defaultValue}
+        defaultValue={defaultValue}
         onMenuOpen={onMenuOpen}
         disabled={
           disabled ||

--- a/src/features/analysis/AccessibilityAnalysisForm.tsx
+++ b/src/features/analysis/AccessibilityAnalysisForm.tsx
@@ -130,6 +130,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
 
   useEffect(() => {
     form.resetForm();
+    // We only want to reset the form when the analysis changes, regardless of the form object itself
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [analysis]);
 
@@ -137,6 +138,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
     if (form.isDirty) {
       form.handleSubmit();
     }
+    // We only want to reset the form when the debounced form data changes, regardless of the form object itself
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedFormData]);
 

--- a/src/features/analysis/AccessibilityAnalysisForm.tsx
+++ b/src/features/analysis/AccessibilityAnalysisForm.tsx
@@ -56,6 +56,7 @@ function getInitialFormState(
     waterAllTouched: analysis?.waterAllTouched ?? undefined,
     priorityRoads: analysis?.priorityRoads ?? undefined,
     travelDirection: analysis?.invertDirection ? "from" : "towards",
+    dem: analysis?.dem,
     landCover: analysis?.landCover,
     knightMove: analysis?.knightMove ?? undefined,
     transportNetwork: analysis?.transportNetwork,
@@ -127,6 +128,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
     },
   });
   const debouncedFormData = useDebounce(form.formData, 500);
+  console.log(form.formData);
 
   useEffect(() => {
     form.resetForm();

--- a/src/features/analysis/AccessibilityAnalysisForm.tsx
+++ b/src/features/analysis/AccessibilityAnalysisForm.tsx
@@ -176,8 +176,10 @@ const AccessibilityAnalysisForm = (props: Props) => {
 
       {/* Step 1 */}
 
-      <AnalysisStep id="friction" title="Generate Friction Map" defaultOpen>
-        <p className="mb-4">Description</p>
+      <AnalysisStep id="friction" title="Friction Surface" defaultOpen>
+        <p className="mb-4">
+          Choose the geographic layers used to generate the friction surface.
+        </p>
         <div className="grid md:grid-cols-2 gap-4">
           <Field label="Digital Elevation Model" name="dem" required>
             <DatasetPicker
@@ -265,10 +267,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
         title={"Health Facilities"}
         className="space-y-4"
       >
-        <p>
-          Description of the analysis. Sed ut perspiciatis unde omnis iste natus
-          error sit voluptatem
-        </p>
+        <p>Choose the health facilities layer.</p>
         <Field
           name="healthFacilities"
           required
@@ -288,7 +287,9 @@ const AccessibilityAnalysisForm = (props: Props) => {
       {/* Step 3 */}
 
       <AnalysisStep id="travelScenario" title={"Travel Scenario"}>
-        <p className="mb-4">Description</p>
+        <p className="mb-4">
+          Assign moving speeds to each category of road network and land cover.
+        </p>
         <Field
           name="movingSpeeds"
           required
@@ -313,7 +314,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
         className="space-y-4"
       >
         <p>Description</p>
-        <Field name="analysisType" label="Travel Direction" required>
+        <Field name="algorithm" label="Cost distance analysis method" required>
           <RadioGroup
             name="algorithm"
             onChange={form.handleInputChange}
@@ -321,11 +322,11 @@ const AccessibilityAnalysisForm = (props: Props) => {
             options={[
               {
                 id: AccessmodAccessibilityAnalysisAlgorithm.Isotropic,
-                label: "Isotropic (no DEM)",
+                label: "Isotropic",
               },
               {
                 id: AccessmodAccessibilityAnalysisAlgorithm.Anisotropic,
-                label: "Anisotropic (use DEM)",
+                label: "Anisotropic",
               },
             ]}
           />

--- a/src/features/analysis/AccessibilityAnalysisForm.tsx
+++ b/src/features/analysis/AccessibilityAnalysisForm.tsx
@@ -149,7 +149,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
     }
 
     if (await launchAnalysis(analysis)) {
-      router.push({
+      await router.push({
         pathname: routes.project_analysis,
         query: { projectId: project.id, analysisId: analysis.id },
       });
@@ -157,7 +157,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
       setTriggering(false);
       setError("Computation failed. Check your input data");
     }
-  }, [form.formData]);
+  }, [analysis, form, project, router]);
 
   return (
     <div className="space-y-5">

--- a/src/features/analysis/AccessibilityAnalysisForm.tsx
+++ b/src/features/analysis/AccessibilityAnalysisForm.tsx
@@ -179,7 +179,16 @@ const AccessibilityAnalysisForm = (props: Props) => {
       <AnalysisStep id="friction" title="Generate Friction Map" defaultOpen>
         <p className="mb-4">Description</p>
         <div className="grid md:grid-cols-2 gap-4">
-          <Field label="Land Cover" name="landCover" required className="">
+          <Field label="Digital Elevation Model" name="dem" required>
+            <DatasetPicker
+              project={project}
+              roleCode={AccessmodFilesetRoleCode.Dem}
+              value={form.formData.dem}
+              required
+              onChange={(value) => form.setFieldValue("dem", value)}
+            />
+          </Field>
+          <Field label="Land Cover" name="landCover" required>
             <DatasetPicker
               project={project}
               roleCode={AccessmodFilesetRoleCode.LandCover}
@@ -188,12 +197,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
               onChange={(value) => form.setFieldValue("landCover", value)}
             />
           </Field>
-          <Field
-            label="Transport Network"
-            name="transportNetwork"
-            required
-            className=""
-          >
+          <Field label="Transport Network" name="transportNetwork" required>
             <DatasetPicker
               project={project}
               roleCode={AccessmodFilesetRoleCode.TransportNetwork}
@@ -204,7 +208,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
               }
             />
           </Field>
-          <Field label="Barriers" name="barrier" required className="">
+          <Field label="Barriers" name="barrier" required>
             <DatasetPicker
               project={project}
               roleCode={AccessmodFilesetRoleCode.Barrier}
@@ -213,7 +217,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
               onChange={(value) => form.setFieldValue("barrier", value)}
             />
           </Field>
-          <Field label="Water" name="water" required className="">
+          <Field label="Water" name="water" required>
             <DatasetPicker
               project={project}
               roleCode={AccessmodFilesetRoleCode.Water}
@@ -222,7 +226,7 @@ const AccessibilityAnalysisForm = (props: Props) => {
               onChange={(value) => form.setFieldValue("water", value)}
             />
           </Field>
-          <Field label="Slope" name="slope" required className="">
+          <Field label="Slope" name="slope" required>
             <DatasetPicker
               project={project}
               roleCode={AccessmodFilesetRoleCode.Slope}
@@ -237,9 +241,8 @@ const AccessibilityAnalysisForm = (props: Props) => {
             value={form.formData.maxSlope}
             onChange={form.handleInputChange}
             type="number"
-            className=""
           />
-
+          <br />
           <Checkbox
             label="Roads have priority over water cells"
             checked={form.formData.priorityRoads}

--- a/src/features/analysis/AnalysisTypePicker.tsx
+++ b/src/features/analysis/AnalysisTypePicker.tsx
@@ -14,7 +14,7 @@ const OPTIONS = [
     value: AccessmodAnalysisType.Accessibility,
     label: "Accessibility Analysis",
     description:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elitUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+      "Compute the traveling time surface, informing the time needed to reach the nearest health facility.",
   },
 ];
 


### PR DESCRIPTION
This PR:

- [x] Adds the `dem` field in the accessibility form
- [x] Disables the "use recommended dataset" option for now, as it is not implemented in the backend
- [x] Updates the copy of the analysis form
- [x] Removes apparently useless `classname=""` props on fields (to check)

Remaining issues:
- [x] The dem field does not work properly - its value is reset on blur