### PR TITLE
Simplify category column in TN fileset picker

### DIFF
--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -194,6 +194,7 @@
   "Team {{name}}": "Team {{name}}",
   "Team name": "Team name",
   "Teams": "Teams",
+  "The exact name of the column in the file that contains the road category": "The exact name of the column in the file that contains the road category",
   "The spatial resolution refers to the linear spacing of a measurement.": "The spatial resolution refers to the linear spacing of a measurement.",
   "The user or team responsible for this project": "The user or team responsible for this project",
   "The user that created this project": "The user that created this project",

--- a/public/locales/fr/messages.json
+++ b/public/locales/fr/messages.json
@@ -197,6 +197,7 @@
   "Team {{name}}": "",
   "Team name": "",
   "Teams": "",
+  "The exact name of the column in the file that contains the road category": "",
   "The spatial resolution refers to the linear spacing of a measurement.": "",
   "The user or team responsible for this project": "",
   "The user that created this project": "",

--- a/src/features/dataset/DatasetMetadataForm.tsx
+++ b/src/features/dataset/DatasetMetadataForm.tsx
@@ -30,16 +30,14 @@ const DatasetMetadataForm = (props: DatasetMetadataFormProps) => {
         <>
           <Field
             name="category_column"
-            list="categories"
             label={t("Category column")}
             type="text"
+            help={t(
+              "The exact name of the column in the GPKG file that contains the road category"
+            )}
             onChange={(e) => setValues({ category_column: e.target.value })}
             required
           />
-          <datalist id="categories">
-            <option value="highway" />
-            <option value="category_column" />
-          </datalist>
         </>
       )}
     </>

--- a/src/features/dataset/DatasetMetadataForm.tsx
+++ b/src/features/dataset/DatasetMetadataForm.tsx
@@ -33,7 +33,7 @@ const DatasetMetadataForm = (props: DatasetMetadataFormProps) => {
             label={t("Category column")}
             type="text"
             help={t(
-              "The exact name of the column in the GPKG file that contains the road category"
+              "The exact name of the column in the file that contains the road category"
             )}
             onChange={(e) => setValues({ category_column: e.target.value })}
             required


### PR DESCRIPTION
The select with options that we implemented is not a good option :

- The demo dataset had another value for the category column
- We can't exclude that other tests will involve gpkg with yet another category column name

This PR replaces the list with a proper help text. We have planned a smarter handling (that involves backend calls) for the next sprint.